### PR TITLE
Add root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lite-hello-mfe-root",
+  "private": true,
+  "workspaces": [
+    "host-app",
+    "mfe-hello"
+  ],
+  "scripts": {
+    "install": "yarn workspaces focus",
+    "dev": "yarn workspace host-app dev",
+    "dev:mfe-hello": "yarn workspace mfe-hello dev",
+    "dev:host": "yarn workspace host-app dev",
+    "build": "yarn workspace mfe-hello build && yarn workspace host-app build",
+    "lint": "yarn workspace mfe-hello lint && yarn workspace host-app lint"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `package.json` at repo root for workspace management

## Testing
- `yarn install` *(fails: Bad response 403 due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_6859c688d9c88325bbf0717fa22e28fa