### PR TITLE
Add helper scripts for local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Lite Hello MFE
+
+This repository contains a minimal micro front-end setup using Yarn workspaces.
+
+## Useful Scripts
+
+- `yarn all-local`: Build all micro front-ends and start each one in preview mode.
+- `yarn dev:all`: Start every micro front-end in development mode with hot reload.
+- `yarn docker:up`: Use docker compose to build and run all services.
+
+Each command must be run from the repository root.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "dev:mfe-hello": "yarn workspace mfe-hello preview",
     "dev:host": "yarn workspace host-app dev",
     "build": "yarn workspace mfe-hello build && yarn workspace host-app build",
-    "lint": "yarn workspace mfe-hello lint && yarn workspace host-app lint"
+    "lint": "yarn workspace mfe-hello lint && yarn workspace host-app lint",
+    "all-local": "yarn build && concurrently -k \"yarn workspace mfe-hello preview\" \"yarn workspace host-app preview\"",
+    "dev:all": "concurrently -k \"yarn workspace mfe-hello dev\" \"yarn workspace host-app dev\"",
+    "docker:up": "docker compose up --build"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add scripts to run every MFE in preview, dev, and docker compose
- document new helper scripts

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6859ca8cde9c83258306845361892ec9